### PR TITLE
Add hydrogen to REMOVE_FRAGMENTS list

### DIFF
--- a/molvs/fragment.py
+++ b/molvs/fragment.py
@@ -51,6 +51,7 @@ class FragmentPattern(object):
 #: The default list of :class:`FragmentPatterns <molvs.fragment.FragmentPattern>` to be used by
 #: :class:`~molvs.fragment.FragmentRemover`.
 REMOVE_FRAGMENTS = (
+	FragmentPattern('hydrogen', '[H]'),
     FragmentPattern('fluorine', '[F]'),
     FragmentPattern('chlorine', '[Cl]'),
     FragmentPattern('bromine', '[Br]'),


### PR DESCRIPTION
Hey Matt,

Really enjoying MolVS, thanks! Just thought I'd suggest this change as the current `FragmentRemover` class doesn't remove the entire salt if the proton is present.

Apologies if there's a reason this isn't in there already. Just thought it was quick enough for a small PR.

![screen shot 2018-02-27 at 11 28 52](https://user-images.githubusercontent.com/7643238/36727625-df10361a-1bb5-11e8-8cfa-50478662add9.png)

Cheers,
Josh